### PR TITLE
Configure Github Actions tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,17 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: '14.x'
+    - name: Setup
+      run: npm run setup
+    - name: Tests
+      run: npm run test:ci

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "olsk-express",
     
     "test": "olsk-spec",
+    "test:ci": "olsk-spec --ci",
 
     "build": "olsk-rollup",
     "watch": "olsk-rollup-watch"


### PR DESCRIPTION
This PR configures [Github Actions](https://github.com/features/actions) to run tests on each commit and pull request.

It is not working at the moment because you need to merge https://github.com/olsk/OLSKSpec/pull/1 first. You can see an example of how it works in this branch of my fork: https://github.com/NoelDeMartin/hyperdraft/commits/ci-tests-sample

There are a couple of improvements you can think about for the future, in particular:

- You could use `npm ci` instead of `npm install`. This uses the `package-lock.json` file to make sure that you're getting the exact same dependencies the project depends on. At the moment, this command fails because there is no `package-lock.json` file in the repository.
- If you include a `.nvmrc` file, you could use something like [actions/read-nvmrc](https://github.com/marketplace/actions/read-nvmrc) to avoid hard-coding a version of node in the workflow. If you don't want to use nvm, I'm sure there is a way to do something similar reading from the package's `engines.node`, but I haven't done it myself.

Also, I used Github Actions because you're already hosting the code here so I thought you wouldn't mind using them. But if you don't like this for some reason, there are other solutions you can use such as [SempahoreCI](https://semaphoreci.com/), [TravisCI](https://www.travis-ci.com/), etc. The setup should be fairly similar. If you don't like the idea of adding new files to your project, I think there are some platforms that allow you to configure this on their dashboard. I used to do it with SemaphoreCI, but I started using files because I prefer to configure them on my code editor than having to log into their dashboard. It's also nice to have this tracked in the repository because it could be helpful for others who are having issues running the project locally.

Finally, one note on the code itself. I've noticed there is a lot of trailing whitespace, and this was annoying to contribute because I have a setting in my code editor that automatically removes it. So I had to disable it and make the code changes again before making the commit. Maybe you can consider using a similar setting yourself. If you're using Sublime Text, I'd recommend installing something like [this package](https://packagecontrol.io/packages/Highlight%20Trailing%20Whitespace) to show it visually in case you don't have the setting or forget to remove it.